### PR TITLE
Fetch Upstream and Slack Notification settings update

### DIFF
--- a/.github/workflows/slack-notify-build.yml
+++ b/.github/workflows/slack-notify-build.yml
@@ -2,7 +2,7 @@ name: R-CMD-check
 
 on:
   - push
-  - pull_request
+  # - pull_request
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # PerformanceAnalytics: Econometric tools for performance and risk analysis.
 
 <!-- badges: start -->
-[![R-CMD-check](https://github.com/jaymon0703/PerformanceAnalytics/workflows/R-CMD-check/badge.svg)](https://github.com/jaymon0703/PerformanceAnalytics/actions)
+[![R-CMD-check](https://github.com/braverock/PerformanceAnalytics/workflows/R-CMD-check/badge.svg)](https://github.com/braverock/PerformanceAnalytics/actions)
 [![Travis Build
 Status](https://travis-ci.org/braverock/PerformanceAnalytics.svg?branch=master)](https://travis-ci.org/braverock/PerformanceAnalytics)
 [![Downloads from the RStudio CRAN mirror](https://cranlogs.r-pkg.org/badges/PerformanceAnalytics)](https://cran.r-project.org/package=PerformanceAnalytics)


### PR DESCRIPTION
Fetch from the upstream branch and update slack notification setting to fire notification on just a push instead of also pull request.